### PR TITLE
Bump toolsversion to 4.0 to allow building.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -13,9 +13,9 @@ if %PROCESSOR_ARCHITECTURE%==x86 (
 :build
 echo ---------------------------------------------------------------------
 echo Building AnyCpu release...
-%msbuild% MetroFramework.sln %commonflags% /tv:3.5 /p:TargetFrameworkVersion=v2.0 /p:Platform="Any Cpu" /p:OutputPath="%outputdir%\AnyCpu\NET20"
+%msbuild% MetroFramework.sln %commonflags% /tv:4.0 /p:TargetFrameworkVersion=v2.0 /p:Platform="Any Cpu" /p:OutputPath="%outputdir%\AnyCpu\NET20"
 if errorlevel 1 goto build-error
-%msbuild% MetroFramework.sln %commonflags% /tv:3.5 /p:TargetFrameworkVersion=v3.5 /p:Platform="Any Cpu" /p:OutputPath="%outputdir%\AnyCpu\NET35"
+%msbuild% MetroFramework.sln %commonflags% /tv:4.0 /p:TargetFrameworkVersion=v3.5 /p:Platform="Any Cpu" /p:OutputPath="%outputdir%\AnyCpu\NET35"
 if errorlevel 1 goto build-error
 %msbuild% MetroFramework.sln %commonflags% /tv:4.0 /p:TargetFrameworkVersion=v4.0 /p:Platform="Any Cpu" /p:OutputPath="%outputdir%\AnyCpu\NET40"
 if errorlevel 1 goto build-error


### PR DESCRIPTION
Bump toolsversion to 4.0 to allow building, with optional parameters. 

Optional parameters from these two files:
\MetroGrid.cs
\MetroMessageBox.cs
