### PR TITLE
Added a location for solution dlls when built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+#All built dlls
+MetroFramework DLLs/*.dll

--- a/MetroFramework DLLs/notes.txt
+++ b/MetroFramework DLLs/notes.txt
@@ -1,0 +1,1 @@
+When building the solution, all the dll's are copied here for easy reference to other projects

--- a/MetroFramework.Design/MetroFramework.Design.csproj
+++ b/MetroFramework.Design/MetroFramework.Design.csproj
@@ -69,6 +69,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy /y $(TargetPath) $(SolutionDir)build</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MetroFramework.Fonts/MetroFramework.Fonts.csproj
+++ b/MetroFramework.Fonts/MetroFramework.Fonts.csproj
@@ -59,6 +59,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy /y $(TargetPath) $(SolutionDir)build</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MetroFramework/MetroFramework.csproj
+++ b/MetroFramework/MetroFramework.csproj
@@ -258,6 +258,9 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy /y $(TargetPath) $(SolutionDir)build</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
When building the solution, all the dll's are copied into the
"MetroFramework DLLs" for easy reference to other projects
